### PR TITLE
Update rpio

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,6 @@
   },
   "homepage": "https://github.com/SerafinTech/node-apa102-spi#readme",
   "dependencies": {
-    "rpio": "0.9.22"
+    "rpio": ">1.2.0"
   }
 }


### PR DESCRIPTION
In node v12 there's a make error for rpio that was fixed as of rpio 1.2.X.